### PR TITLE
fix error upgrading when trying to backup var/rw/nagios.cmd

### DIFF
--- a/tasks/build-nagios.yml
+++ b/tasks/build-nagios.yml
@@ -43,7 +43,6 @@
     - "/usr/local/nagios/share/side.html"
     - "{{ with_httpd_conf }}/nagios.conf"
     - "/usr/local/nagios/bin/nagios"
-    - "/usr/local/nagios/var/rw"
     - "/usr/local/nagios/include/nagios/nagios.h"
     - "/etc/init.d/nagios"
   when: nagios_upgrade_required


### PR DESCRIPTION
small fix to avoid error when doing upgrade (shouldn't try to backup nagios.cmd) 